### PR TITLE
#85 Mise à jour du mode de récupération de la requête sous forme d'objet

### DIFF
--- a/motorMVC/Manager/CrudManager.php
+++ b/motorMVC/Manager/CrudManager.php
@@ -485,7 +485,6 @@ class CrudManager extends BddManager implements PaginatePerPage
         endswitch;
     }
 
-    /** NOTE - Valide */
     public function getByIdOrder($clientId)
     {
         /*
@@ -588,8 +587,8 @@ class CrudManager extends BddManager implements PaginatePerPage
             INNER JOIN images i ON i.id = pi.images_id
             WHERE o.users_id = :client_id AND o.basket = 1',
         );
-        $req->execute([':client_id' => $clientId]);
-        $req->setFetchMode(\PDO::FETCH_CLASS | \PDO::FETCH_PROPS_LATE, $this->_objectClass);
+        $req->execute(['client_id' => $clientId]);
+        $req->setFetchMode(\PDO::FETCH_OBJ);
 
         return $req->fetchAll();
     }


### PR DESCRIPTION
## Erreur de renvoie des données

### Après avoir vérifié si la requête SQL était correct, l'erreur provenait de façon dont les données étaient renvoyée.
Les données renvoyées sous forme d'objet de Classe n'était pas reconnue par Stripe product_data

```php
 $req->setFetchMode(\PDO::FETCH_CLASS | \PDO::FETCH_PROPS_LATE, $this->_objectClass);
```
Cela a été modifié pour renvoyé les données directement sous forme d'objet, sans changé le code d'hydratation des données pour Stripe

```php
$req->setFetchMode(\PDO::FETCH_OBJ);
```
