### PR TITLE
Stripe checkout erreur

### DIFF
--- a/backend-php/public_html/index.php
+++ b/backend-php/public_html/index.php
@@ -176,10 +176,10 @@ $router->map('GET', '/basket', 'StripeController#Index', 'basket');
 // Route renvoyant sur l'API Stripe checkout
 $router->map('GET', '/stripe/pay', 'StripeController#Pay', 'pay');
 
-// // Route si le paiment est abandonné
+// Route si le paiment est abandonné
 $router->map('GET', '/stripe/cancel', 'StripeController#Cancel', 'cancel');
 
-// // Route si le paiement est confirmé
+// Route si le paiement est confirmé
 $router->map('GET', '/stripe/success', 'StripeController#Success', 'success');
 
 /*

--- a/backend-php/src/Controllers/PanierController.php
+++ b/backend-php/src/Controllers/PanierController.php
@@ -48,7 +48,7 @@ class PanierController
             header('Location: /inscription');
             exit();
         }
-        var_dump($arguments);
+    
         /** @var \Motor\Mvc\Utils\Render */
         $render = $arguments['render'];
         $IdclientCrudManager = new CrudManager('users', Users::class);

--- a/backend-php/src/Controllers/StripeController.php
+++ b/backend-php/src/Controllers/StripeController.php
@@ -43,6 +43,8 @@ class StripeController
 
                     $arguments['render']->addParams('commande', $commande);
 
+                    
+
                     $content = $arguments['render']->render('stripe/success', $arguments);
 
                     unset($_COOKIE['stripe']); 

--- a/backend-php/src/Enum/ClientExceptionEnum.php
+++ b/backend-php/src/Enum/ClientExceptionEnum.php
@@ -6,4 +6,5 @@ enum ClientExceptionEnum
 {
   case NotFound404;
   case AccountIsRegistered;
+  case KeyNotFound;
 }

--- a/backend-php/src/Exceptions/ClientExceptions.php
+++ b/backend-php/src/Exceptions/ClientExceptions.php
@@ -12,6 +12,7 @@ class ClientExceptions extends \Exception
     match ($case) {
       ClientExceptionEnum::NotFound404   =>  parent::__construct("Ooops la page que vous souhaitez consulter est introuvable.", 404),
       ClientExceptionEnum::AccountIsRegistered   =>  parent::__construct("Compte deja enregistre avec ce mail.", 401),
+      ClientExceptionEnum::KeyNotFound   =>  parent::__construct("Paiement inaccessible.", 401),
     };
   }
 }

--- a/backend-php/src/Stripe/StripePayment.php
+++ b/backend-php/src/Stripe/StripePayment.php
@@ -2,6 +2,10 @@
 
 namespace App\Boutique\Stripe;
 
+use App\Boutique\Enum\ClientExceptionEnum;
+use App\Boutique\Exceptions\ClientExceptions;
+use Error;
+use Exception;
 use Motor\Mvc\Components\DockerSecrets;
 use Motor\Mvc\Enum\SecretsEnum;
 use Stripe\Checkout\Session;
@@ -16,8 +20,9 @@ class StripePayment
     {
         // TODO Voir où enregistrer la clé d'API
         $stripeSecretKey = DockerSecrets::getSecrets(SecretsEnum::Api_Key_Stripe);
-
-        \Stripe\Stripe::setApiKey($stripeSecretKey);
+        try {
+            \Stripe\Stripe::setApiKey($stripeSecretKey);
+       
 
         $YOUR_DOMAIN = 'http://boutique-js.test:8880/';
 
@@ -49,7 +54,7 @@ class StripePayment
                 ];
             }
         }
-
+        
         $session = Session::create([
             'line_items' => $line_items,
             'mode' => 'payment',
@@ -60,8 +65,10 @@ class StripePayment
                 'allowed_countries' => ['FR'],
             ],
         ]);
-        // Voir implementation d'image de produits par Content Delivery Network
-
+         } catch (Exception $e){
+            throw new ClientExceptions(ClientExceptionEnum::KeyNotFound);
+        }
+        
         // Voir nécéssité des header
         header('HTTP/1.1 303 See Other');
         header('Location: ' . $session->url);


### PR DESCRIPTION
## Gestion d'erreur

- L'acccès à la page de paiement stripe sans clé valide ne renvoie plus une page d'erreur, mais une page 401 paiement inaccessible